### PR TITLE
Implementação links: TVI Reality e TVI Africa M3U8

### DIFF
--- a/m3upt.m3u
+++ b/m3upt.m3u
@@ -99,7 +99,13 @@ https://video-auth2.iol.pt/live_tvi_ficcao/live_tvi_ficcao/edge_servers/tvificca
 #EXTINF:-1 group-title="TV" tvg-id="TVIR.meo.pt" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/TVI-Reality.png",TVI Reality
 #KODIPROP:inputstream=inputstream.adaptive
 #KODIPROP:inputstream.adaptive.manifest_type=hls
-https://video-auth2.iol.pt/live_tvi_direct/live_tvi_direct/edge_servers/tvireality-480p/playlist.m3u8
+https://video-auth4.iol.pt/live_tvi_direct/live_tvi_direct/edge_servers/tvireality-480p/chunks.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9MTIvMTAvMjAyMiA5OjIwOjIxIFBNJmhhc2hfdmFsdWU9UkNTS2NjemFiY002WG44UTM2STZRZz09JnZhbGlkbWludXRlcz0xNDQwJmlkPWUyZjI2MjI5LTc4YWUtNDg0My1hMzczLWExMjAwMjIxZjY1MQ==
+Alt: https://video-auth4.iol.pt/live_tvi_direct/live_tvi_direct/edge_servers/tvireality-720_passthrough/chunks.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9MTIvMTAvMjAyMiA5OjIwOjIxIFBNJmhhc2hfdmFsdWU9UkNTS2NjemFiY002WG44UTM2STZRZz09JnZhbGlkbWludXRlcz0xNDQwJmlkPWUyZjI2MjI5LTc4YWUtNDg0My1hMzczLWExMjAwMjIxZjY1MQ==
+
+#EXTINF:-1 group-title="TV" tvg-id="TVIAFR.meo.pt" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/TVI-Ficção.png",TVI Africa
+#KODIPROP:inputstream=inputstream.adaptive
+#KODIPROP:inputstream.adaptive.manifest_type=hls
+https://video-auth4.iol.pt/live_tvi_africa/live_tvi_africa/edge_servers/tviafrica-480p/playlist.m3u8   #Necessita a troca de logo para TVI-Africa.png
 
 #EXTINF:-1 group-title="TV" tvg-id="portochd.tv.vodafone.pt" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/Porto-Canal.png",Porto Canal
 #KODIPROP:inputstream=inputstream.adaptive


### PR DESCRIPTION
Decidi fazer esta alteração. Devido que a TVI atualmente adiciona token no canal TVI Reality, Adicionei também o link a funcionar para TVI Africa (Sem precisar de token) (Coloquei dois links na secção TVI Reality, um como alternativo devido à resolução)

Existe um problema somente no canal TVI Reality. Passado alguns breves segundos a ligação ao link deixará de funcionar temporáriamente. É uma questão de testarem com o Kodi e VLC com vossa internet...

Uma dica: os canais de TVI que contém o endereço [video-auth] o número correspondente por exemplo 4. São versões alternativas e por normal a latência muda. Por isso decidi escolher o video-auth4 por ter menos latência de transmissão e ser muito próximo a resposta de conexão de BOX Vodafone, Meo etc.. 

Espero que esta minha recente colaboração vos ajude a manter lista atualizada.