### PR TITLE
Atualização de link TVI e CNN_PT 480p para 720P

### DIFF
--- a/m3upt.m3u
+++ b/m3upt.m3u
@@ -22,7 +22,7 @@ https://d1zx6l1dn8vaj5.cloudfront.net/out/v1/b89cc37caa6d418eb423cf092a2ef970/in
 #EXTINF:-1 group-title="TV" tvg-id="tvihd.tv.vodafone.pt" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/TVI.png",TVI
 #KODIPROP:inputstream=inputstream.adaptive
 #KODIPROP:inputstream.adaptive.manifest_type=hls
-https://video-auth6.iol.pt/live_tvi/live_tvi/playlist.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9MTIvMTEvMjAyMiAzOjE3OjMgUE0maGFzaF92YWx1ZT15YUFsTXJFK0lBTmkzQUNYSy92dXN3PT0mdmFsaWRtaW51dGVzPTE0NDAmaWQ9OWRkNGY4ZmQtYzg2Yi00NTlmLWEzMzUtNjMxYzc4MWMyNzE5/
+https://video-auth4.iol.pt/live_tvi/live_tvi/edge_servers/tvi-720_passthrough/chunks.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9MTIvMTEvMjAyMiAzOjE3OjMgUE0maGFzaF92YWx1ZT15YUFsTXJFK0lBTmkzQUNYSy92dXN3PT0mdmFsaWRtaW51dGVzPTE0NDAmaWQ9OWRkNGY4ZmQtYzg2Yi00NTlmLWEzMzUtNjMxYzc4MWMyNzE5/
 
 #EXTINF:-1 group-title="TV" tvg-id="rtp3hd.tv.vodafone.pt" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/RTP3.png",RTP 3
 #KODIPROP:inputstream=inputstream.adaptive
@@ -38,7 +38,7 @@ https://sicnot.live.impresa.pt/sicnot.m3u8
 #EXTINF:-1 group-title="TV" tvg-id="cnnpthd.tv.vodafone.pt" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/CNN-Portugal.png",CNN Portugal
 #KODIPROP:inputstream=inputstream.adaptive
 #KODIPROP:inputstream.adaptive.manifest_type=hls
-https://video-auth7.iol.pt/live_cnn/live_cnn/playlist.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9MTIvMTEvMjAyMiAzOjE3OjQgUE0maGFzaF92YWx1ZT1Oak9YK2dNSnV0cTlGNklhQVZRWW5nPT0mdmFsaWRtaW51dGVzPTE0NDAmaWQ9ZWM0Zjc3ZWQtY2EwZi00NTM5LWE5ZTUtOGU4MDY3ODhiNGUy/
+https://video-auth4.iol.pt/live_cnn/live_cnn/edge_servers/cnn-720p/chunks.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9MTIvMTEvMjAyMiAzOjE3OjQgUE0maGFzaF92YWx1ZT1Oak9YK2dNSnV0cTlGNklhQVZRWW5nPT0mdmFsaWRtaW51dGVzPTE0NDAmaWQ9ZWM0Zjc3ZWQtY2EwZi00NTM5LWE5ZTUtOGU4MDY3ODhiNGUy/
 
 #EXTINF:-1 group-title="TV" tvg-id="" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/CNN-Brasil.png",CNN Brasil
 #KODIPROP:inputstream=inputstream.adaptive


### PR DESCRIPTION
Atualizei o endereço de TVI e CNN_PT 480p para 720p para melhor qualidade.