### PR TITLE
Guard streams.sh against empty token from IOL endpoint (fixes #177)

### DIFF
--- a/M3U/streams.sh
+++ b/M3U/streams.sh
@@ -4,6 +4,15 @@
 
 # Update the stream URL of all TVI channels
 
-sed -i "s#wmsAuthSign=[^&]*#wmsAuthSign=$(wget -qO- https://services.iol.pt/matrix?userId -o /dev/null)#g" *.m3u8
+TOKEN=$(wget -qO- --timeout=15 --tries=2 https://services.iol.pt/matrix?userId)
+
+# If the token comes back empty (endpoint down), keep the existing valid token
+# instead of blanking it across all files.
+if [ -z "$TOKEN" ]; then
+  echo "Empty token from IOL endpoint — keeping existing tokens."
+  exit 0
+fi
+
+sed -i "s#wmsAuthSign=[^&]*#wmsAuthSign=${TOKEN}#g" *.m3u8
 
 exit 0


### PR DESCRIPTION
## Summary

The `Update streams` Action regressed the fix for #177 on 2026-07-09 (~07:00 WEST), blanking `wmsAuthSign` across all 6 IOL `.m3u8` files at once.

**Root cause:** `M3U/streams.sh` fetches the token via `wget` with **no timeout**. When `services.iol.pt/matrix?userId` hangs (it did in the run starting 05:21 UTC), `wget` returns empty after ~47 min and the `sed` replaces the still-valid token with `wmsAuthSign=` (blank). Because the script ends with `exit 0`, the run is reported as **success** — every stream goes dark with no error signal.

**Evidence:**
- Commit e8876ce ("Update streams" at 06:08 UTC) blanked the tokens.
- Run log shows a ~47 min gap between `bash streams.sh` and the next step with no output.
- Confirmed reversible: the next run at 09:08 UTC (endpoint healthy) restored the tokens (commit 35cbf243f).

## Fix

Fetch the token into a variable **with a timeout**, and if it comes back empty, keep the existing valid tokens instead of overwriting them:

```bash
TOKEN=$(wget -qO- --timeout=15 --tries=2 https://services.iol.pt/matrix?userId)
if [ -z "$TOKEN" ]; then
  echo "Empty token from IOL endpoint — keeping existing tokens."
  exit 0
fi
sed -i "s#wmsAuthSign=[^&]*#wmsAuthSign=${TOKEN}#g" *.m3u8
```

This way a temporary IOL outage no longer wipes the still-valid (24h) token across all channels.

Closes #177.

## Test plan

- [ ] Trigger `Update streams` Action with endpoint reachable → tokens updated normally.
- [ ] Simulate empty token (e.g. point `wget` at a dead URL) → files unchanged, run still exits 0, message logged.