### PR TITLE
Added new radio station: RFPtv - Rádio só Folclore de Portugal tv

### DIFF
--- a/M3U/M3UPT.m3u
+++ b/M3U/M3UPT.m3u
@@ -904,6 +904,9 @@ https://centova.radio.com.pt/proxy/558
 #EXTINF:-1 radio="true" group-title="Rádios" tvg-logo="http://www.radiovaledominho.com/wp-content/uploads/2017/09/logo_rvm-01.png",Rádio Vale do Minho
 http://centova.radio.com.pt:9434
 
+#EXTINF:-1 radio="true" group-title="Rádios" tvg-logo="https://rfptv.pt/uploads/img_6a48101830d423.07827183.png",RFPtv - Rádio só Folclore de Portugal tv
+https://sonic.servsonic.com:8012/stream
+
 #EXTINF:-1 radio="true" group-title="Rádios" tvg-logo="https://www.radio.pt/images/broadcasts/c5/77/38212/1/c300.png",Rádio Quântica
 https://libretime.radioquantica.com/main.mp3
 


### PR DESCRIPTION
Added new radio station: RFPtv - Rádio só Folclore de Portugal tv

<img width="1052" height="710" alt="imagem" src="https://github.com/user-attachments/assets/7dbb257a-df6a-4ed8-a001-11fa9d40169a" />
