### PR TITLE
Fix duplicated group-title attribute in Euronews PT entry

### DIFF
--- a/M3U/M3UPT.m3u
+++ b/M3U/M3UPT.m3u
@@ -49,7 +49,7 @@ https://github.com/LITUATUI/M3UPT/raw/main/M3U/CNN_Portugal.m3u8
 #EXTINF:-1 group-title="TV" tvg-id="CNNBrasil.br" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/CNN-Brasil.png",CNN Brasil
 https://d25usgadhphvwi.cloudfront.net/hls/main.m3u8
 
-#EXTINF:-1 group-title="TV" group-title="TV" tvg-id="EuronewsPortuguese.fr" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/euronews-logo-225x225.png",Euronews PT
+#EXTINF:-1 group-title="TV" tvg-id="EuronewsPortuguese.fr" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/euronews-logo-225x225.png",Euronews PT
 https://6e52fb8b.wurl.com/master/f36d25e7e52f1ba8d7e56eb859c636563214f541/UmxheHhUVi1ldV9FdXJvbmV3c1BvcnR1Z3Vlc19ITFM/playlist.m3u8
 
 #EXTINF:-1 group-title="TV" tvg-id="ARTV.pt" tvg-logo="https://raw.githubusercontent.com/LITUATUI/M3UPT/main/logos/ARTV.png",ARTV


### PR DESCRIPTION
The Euronews PT `#EXTINF` line in `M3U/M3UPT.m3u` had `group-title="TV"` twice:

```
#EXTINF:-1 group-title="TV" group-title="TV" tvg-id="EuronewsPortuguese.fr" ...
```

This is the only entry in the playlist with a duplicated attribute. Some IPTV players parse the channel name from the remainder of the line after `group-title="`, and with the attribute repeated they end up showing `TV"` instead of `Euronews PT`.

This removes the duplicate, making the entry consistent with every other line in the playlist.