### PR TITLE
Add Free IPTV Player to recommended IPTV players

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ This simple IPTV player also opens DRM encrypted streams. Excellent experience o
 
 ---
 
+### 🥇 Free IPTV Player
+
+[Free IPTV Player](https://freeiptvplayer.net/iptv-player/) is a free web-based IPTV player: paste an M3U URL or upload an M3U playlist file to play channels directly in the browser, with no app installation required.
+
+[Open the web player](https://freeiptvplayer.net/iptv-player/)
+
+---
+
 ### 🥈ProgTV
 
 This is a good player for Android, but doesn't open DRM encrypted streams. Curiously this player can bypass geo-blocking of SIC channels.

--- a/README.pt.md
+++ b/README.pt.md
@@ -167,6 +167,14 @@ Este leitor de IPTV simples também abre streams encriptados com DRM. Excelente 
 
 ---
 
+### 🥇 Free IPTV Player
+
+O [Free IPTV Player](https://freeiptvplayer.net/iptv-player/) é um leitor de IPTV baseado na web e gratuito: cole um URL M3U ou carregue um ficheiro de playlist M3U para reproduzir canais directamente no navegador, sem necessidade de instalar aplicações.
+
+[Abrir o leitor web](https://freeiptvplayer.net/iptv-player/)
+
+---
+
 ### 🥈 ProgTV
 
 Este é um bom leitor para Android, mas não abre streams encriptados com DRM. Curiosamente, este leitor consegue contornar o bloqueio geográfico dos canais SIC.


### PR DESCRIPTION
Adds [Free IPTV Player](https://freeiptvplayer.net/iptv-player/) — a free browser-based IPTV player (paste an M3U URL or upload an M3U file to play channels in the browser, no app install) — to the "Recommended IPTV players" section of README.md, with the matching update to README.pt.md to keep both languages in sync.

**Disclosure:** I operate freeiptvplayer.net, so this is a self-submission — please judge the entry on its merits.

Verified on 2026-09-10 (from Portugal/EU): the linked web player loads, accepts an M3U URL or file upload, and plays channels directly in the browser. The site is free to use and requires no account, but it is ad-supported and the player does not open DRM-encrypted streams.

The entry follows the existing section style; no screenshots were added since the player is a web page rather than a downloadable app.